### PR TITLE
Add Jupyter notebook for SAS Viya Python Perspective book article

### DIFF
--- a/python/blog-notebooks/sasViyaPythonPerspective.ipynb
+++ b/python/blog-notebooks/sasViyaPythonPerspective.ipynb
@@ -1,0 +1,711 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Jupyter notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This Jupyter notebook provides the commands used in the article [Great tip for dynamic data selection using SAS Viya and Python](https://blogs.sas.com/content/sgf/2018/11/06/great-tip-for-dynamic-data-selection-using-sas-viya-and-python/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import python packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import swat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Connect to the CAS server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "conn = swat.CAS('sasserver.demo.sas.com',8777,'sasdemo','Orion123')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CAS('sasserver.demo.sas.com', 8777, 'sasdemo', protocol='http', name='py-session-1', session='a3000ac4-61fb-784c-a1e5-36ad27c67259')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Upload data into a DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTE: Cloud Analytic Services made the uploaded file available as table IRIS in caslib CASUSER(sasdemo).\n",
+      "NOTE: The table IRIS has been created in caslib CASUSER(sasdemo) from binary data uploaded to Cloud Analytic Services.\n"
+     ]
+    }
+   ],
+   "source": [
+    "df=conn.upload('https://raw.githubusercontent.com/uiuc-cse/data-fa14/gh-pages/data/iris.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Load data into a CAS table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tbl = df.casTable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Sort the stored values in a variable and change the sort order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sorttbl = tbl.sort_values(['sepal_length','sepal_width'],\n",
+    "                         ascending=[False,True])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expression to create filter and display data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "expr = sorttbl.petal_length > 6.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "newtbl = sorttbl[expr]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\"><caption>Selected Rows from Table IRIS</caption>\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th title=\"\"></th>\n",
+       "      <th title=\"sepal_length\">sepal_length</th>\n",
+       "      <th title=\"sepal_width\">sepal_width</th>\n",
+       "      <th title=\"petal_length\">petal_length</th>\n",
+       "      <th title=\"petal_width\">petal_width</th>\n",
+       "      <th title=\"species\">species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>6.9</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>3.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7.6</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>6.6</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Selected Rows from Table IRIS\n",
+       "\n",
+       "   sepal_length  sepal_width  petal_length  petal_width    species\n",
+       "0           7.7          2.6           6.9          2.3  virginica\n",
+       "1           7.7          2.8           6.7          2.0  virginica\n",
+       "2           7.7          3.8           6.7          2.2  virginica\n",
+       "3           7.6          3.0           6.6          2.1  virginica"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "newtbl.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Same expression as above writte on one line"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "newtbl = sorttbl[sorttbl.petal_length > 6.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\"><caption>Selected Rows from Table IRIS</caption>\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th title=\"\"></th>\n",
+       "      <th title=\"sepal_length\">sepal_length</th>\n",
+       "      <th title=\"sepal_width\">sepal_width</th>\n",
+       "      <th title=\"petal_length\">petal_length</th>\n",
+       "      <th title=\"petal_width\">petal_width</th>\n",
+       "      <th title=\"species\">species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>6.9</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>3.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7.6</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>6.6</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Selected Rows from Table IRIS\n",
+       "\n",
+       "   sepal_length  sepal_width  petal_length  petal_width    species\n",
+       "0           7.7          2.6           6.9          2.3  virginica\n",
+       "1           7.7          2.8           6.7          2.0  virginica\n",
+       "2           7.7          3.8           6.7          2.2  virginica\n",
+       "3           7.6          3.0           6.6          2.1  virginica"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "newtbl.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Another expression to change the filter criteria"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "newtbl2 = newtbl[newtbl.petal_width < 2.2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\"><caption>Selected Rows from Table IRIS</caption>\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th title=\"\"></th>\n",
+       "      <th title=\"sepal_length\">sepal_length</th>\n",
+       "      <th title=\"sepal_width\">sepal_width</th>\n",
+       "      <th title=\"petal_length\">petal_length</th>\n",
+       "      <th title=\"petal_width\">petal_width</th>\n",
+       "      <th title=\"species\">species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7.6</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>6.6</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Selected Rows from Table IRIS\n",
+       "\n",
+       "   sepal_length  sepal_width  petal_length  petal_width    species\n",
+       "0           7.7          2.8           6.7          2.0  virginica\n",
+       "1           7.6          3.0           6.6          2.1  virginica"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "newtbl2.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expression to add a bitwise comparison (&) to join the filters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\"><caption>Selected Rows from Table IRIS</caption>\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th title=\"\"></th>\n",
+       "      <th title=\"sepal_length\">sepal_length</th>\n",
+       "      <th title=\"sepal_width\">sepal_width</th>\n",
+       "      <th title=\"petal_length\">petal_length</th>\n",
+       "      <th title=\"petal_width\">petal_width</th>\n",
+       "      <th title=\"species\">species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7.6</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>6.6</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Selected Rows from Table IRIS\n",
+       "\n",
+       "   sepal_length  sepal_width  petal_length  petal_width    species\n",
+       "0           7.7          2.8           6.7          2.0  virginica\n",
+       "1           7.6          3.0           6.6          2.1  virginica"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorttbl[(sorttbl.petal_length > 6.5) &\n",
+    "        (sorttbl.petal_width < 2.2)].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Display the CASTable object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CASTable('IRIS', caslib='CASUSER(sasdemo)', computedvars=['_gt_6_', '_and_8_', '_lt_7_'], computedvarsprogram='_gt_6_ = (petal_length > 6.5); _lt_7_ = (petal_width < 2.2); _and_8_ = (_gt_6_ and _lt_7_); ', where='(_and_8_)')[['sepal_length', 'sepal_width', 'petal_length', 'petal_width', 'species']].sort_values(['sepal_length', 'sepal_width'], ascending=[False, True])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorttbl[(sorttbl.petal_length > 6.5) & \n",
+    "        (sorttbl.petal_width < 2.2)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expression that includes mathematical operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\"><caption>Selected Rows from Table IRIS</caption>\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th title=\"\"></th>\n",
+       "      <th title=\"sepal_length\">sepal_length</th>\n",
+       "      <th title=\"sepal_width\">sepal_width</th>\n",
+       "      <th title=\"petal_length\">petal_length</th>\n",
+       "      <th title=\"petal_width\">petal_width</th>\n",
+       "      <th title=\"species\">species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>2.6</td>\n",
+       "      <td>6.9</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7.7</td>\n",
+       "      <td>3.8</td>\n",
+       "      <td>6.7</td>\n",
+       "      <td>2.2</td>\n",
+       "      <td>virginica</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Selected Rows from Table IRIS\n",
+       "\n",
+       "   sepal_length  sepal_width  petal_length  petal_width    species\n",
+       "0           7.7          2.6           6.9          2.3  virginica\n",
+       "1           7.7          3.8           6.7          2.2  virginica"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorttbl[(sorttbl.petal_length + sorttbl.petal_width)\n",
+    "        * 2 > 17.5].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expression that uses the Python str method to make comparisions on character columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\"><caption>Selected Rows from Table IRIS</caption>\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th title=\"\"></th>\n",
+       "      <th title=\"sepal_length\">sepal_length</th>\n",
+       "      <th title=\"sepal_width\">sepal_width</th>\n",
+       "      <th title=\"petal_length\">petal_length</th>\n",
+       "      <th title=\"petal_width\">petal_width</th>\n",
+       "      <th title=\"species\">species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.8</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5.7</td>\n",
+       "      <td>3.8</td>\n",
+       "      <td>1.7</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5.7</td>\n",
+       "      <td>4.4</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>5.5</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1.3</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.5</td>\n",
+       "      <td>4.2</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Selected Rows from Table IRIS\n",
+       "\n",
+       "   sepal_length  sepal_width  petal_length  petal_width species\n",
+       "0           5.8          4.0           1.2          0.2  setosa\n",
+       "1           5.7          3.8           1.7          0.3  setosa\n",
+       "2           5.7          4.4           1.5          0.4  setosa\n",
+       "3           5.5          3.5           1.3          0.2  setosa\n",
+       "4           5.5          4.2           1.4          0.2  setosa"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorttbl[sorttbl.species.str.upper().str.startswith('SET')\n",
+    "        ].head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Juypter notebook to support the SAS users blog article:  https://blogs.sas.com/content/sgf/2018/11/06/great-tip-for-dynamic-data-selection-using-sas-viya-and-python/